### PR TITLE
Draw peak examples and generate HTML report

### DIFF
--- a/Snakemake.bySample/Snakefile
+++ b/Snakemake.bySample/Snakefile
@@ -85,7 +85,8 @@ sampleDir	= "3.Sample"
 ###########################################################
 ## ** Developmental feature. Please ignore this section
 ## Parameters for k-mer bias correction
-kmer_genome	= "/data/limlab/Resource/Jellyfish.Kmer/%s.6mer.txt" % genome
+#kmer_genome	= "/data/limlab/Resource/Jellyfish.Kmer/%s.6mer.txt" % genome
+kmer_genome = "NULL"
 kmer_pseudo	= 1
 
 
@@ -102,7 +103,7 @@ samples = pd.read_csv(src_sampleInfo, sep="\t", comment="#", na_filter=False)
 ## Cluster configuration
 import yaml
 with open(os.path.expanduser(cluster_yml), 'r') as fh:
-	cluster = yaml.load(fh)
+	cluster = yaml.safe_load(fh)
 
 
 #################################################
@@ -120,6 +121,8 @@ sampleList = samples.Name.tolist()
 sampleListFactor = samples.Name[samples.PeakMode=="factor"].tolist()
 # Samples for histone modification (or broad peaks)
 sampleListHistone = samples.Name[samples.PeakMode=="histone"].tolist()
+# Number of highest scoring peaks to visualize
+numHighestPeaks = 5
 
 rule all:
 	input:
@@ -143,6 +146,13 @@ rule all:
 		expand(sampleDir + "/{sampleName}/Motif/MEME.random5k/meme-chip.html", sampleName=sampleListFactor),
 		## BigWig 1bp raw/abs (motivated for BPnet input file)
 		expand(sampleDir + "/{sampleName}/igv.1bp.raw.abs.{strand}.bw", sampleName=sampleList, strand=["plus","minus"])
+
+		## Draw peak examples
+		expand(sampleDir + "/{sampleName}/HomerPeak.factor/peak.examples.{ext}", sampleName=sampleListFactor, ext=["png","pdf"]),
+		expand(sampleDir + "/{sampleName}/HomerPeak.histone/peak.examples.{ext}", sampleName=sampleListHistone, ext=["png","pdf"]),
+
+		## Create final report
+		"Report.html"
 
 '''
 Output files under Development

--- a/Snakemake.bySample/cluster.yml
+++ b/Snakemake.bySample/cluster.yml
@@ -95,3 +95,7 @@ analyze_footprint_homer_corrected:
     cpu         : 4
     memory      : 10000
 
+create_final_report:
+    name        : "{rule}"
+    output      : "logs/{rule}.out"
+    error       : "logs/{rule}.err"

--- a/cnr.createReportHTML.r
+++ b/cnr.createReportHTML.r
@@ -1,0 +1,116 @@
+#!/usr/bin/env Rscript
+
+#Create pdf/html report using R
+suppressPackageStartupMessages(library('optparse', quiet=TRUE))
+suppressPackageStartupMessages(library('plotly', quiet=TRUE))
+suppressPackageStartupMessages(library('kableExtra', quiet=TRUE))
+suppressPackageStartupMessages(library('data.table', quiet=TRUE))
+suppressPackageStartupMessages(library('cowplot', quiet=TRUE))
+
+option_list <- list(
+	make_option(c("-s","--sampleDir"), help="Path to '3.Sample' directory"),
+	make_option(c("-q","--qcDirectory"), help="Path to '2.1.QualtyControl' directory")#,
+	#make_option(c("-l","--logoImg"), help="Path to Cutlery logo.png")
+)
+parser <- OptionParser(usage = "%prog [options]",
+	description="Description:
+	Creates final HTML report.
+Input:
+	'3.Sample' directory path
+Output:
+    - Report.html",
+	 option_list=option_list)
+arguments <- parse_args(parser, positional_arguments = TRUE)
+
+# Option handling
+opt=arguments$options
+sampDir=opt$sampleDir
+qcDir=opt$qcDirectory
+#logo=opt$logoImg
+logo = paste0(Sys.getenv("CUTLERY"), "/Plan/logo.png")
+
+#count peaks
+countPeaks=function(bed) {
+	countLines <- system(paste0("wc -l ", bed), intern = TRUE, ignore.stdout = FALSE, ignore.stderr = FALSE, wait = TRUE)
+	return(strtoi(strsplit(countLines, "\\s+")[[1]][1]))
+}
+
+#get sum of peak widths
+sumPeaks=function(bed) {
+	getDiffs <- system(paste0("awk '{$1 = $3 - $2} 1 {print $1}' ", bed), intern = TRUE, ignore.stdout = FALSE, ignore.stderr = FALSE, wait = TRUE)
+	return(sum(strtoi(getDiffs)))
+}
+
+#make two tables, one each for histone mode and factor mode
+histoneTable <- data.table(Sample=character(), peakcount=numeric(), widths=numeric())
+factorTable <- data.table(Sample=character(), peakcount=numeric())
+
+#make a copy of the original Rmd file
+template <- paste0(Sys.getenv("CUTLERY"), "/cnr.createReportHTMLTemplate.Rmd")
+system(sprintf("cp %s Report.Rmd", template))
+
+#create separate coverage html files for each sample
+samplePaths <- list.files(sampDir)
+sampleQC <- paste0(sampDir, "/", samplePaths, "/QC")
+
+for (sample in sampleQC) {
+
+	#get sample name
+	sampleName <- tail(unlist(strsplit(sample, "/")), n=2)[1]
+
+	#get path to sample Directory
+	sampleDirectory <- paste(head(unlist(strsplit(sample, "/")), -1), collapse = "/")
+	fileList <- list.files(sampleDirectory)
+	
+	#get heatmap and coverage
+	homerFolderName <- grep("Homer", fileList, value=TRUE)
+	factorMode <- tail(unlist(strsplit(homerFolderName, ".", fixed = TRUE)))[2]
+	homerFolderPath <- paste0(sampleDirectory, "/", homerFolderName)
+	
+	#skip visualization of control samples
+	if (is.null(factorMode)) {
+		next
+	}
+
+	if (factorMode == "factor") {
+		heatmap <- list.files(homerFolderPath, pattern = "*heatmap.exBL.1rpm.png", full.names = TRUE)
+		peakFile <- list.files(homerFolderPath, pattern = "*peak.exBL.1rpm.bed", full.names = TRUE)
+		factorTable <- rbind(factorTable, list(sampleName, countPeaks(peakFile)))
+		#print("currently right after countPeaks function")
+		#print(countPeaks(peakFile))
+	} else {
+		heatmap <- list.files(homerFolderPath, pattern = "*heatmap.exBL.png", full.names = TRUE)
+		peakFile <- list.files(homerFolderPath, pattern = "*peak.exBL.bed", full.names = TRUE)
+		histoneTable <- rbind(histoneTable, list(sampleName, countPeaks(peakFile), sumPeaks(peakFile)))
+	}
+
+	#get all 6 peak coverage plots
+	peakExamplePlot <- list.files(homerFolderPath, pattern = "*peak.examples.png", full.names = TRUE)
+
+	#write Genome Coverage section of Rmd file
+	#add histone heatmap at the end
+	line = paste0("### ", sampleName, " {.tabset}")
+	write(line,file="Report.Rmd",append=TRUE)
+	line="```{r, echo=FALSE, out.width='100%', message=FALSE, warning=FALSE}"
+	write(line,file="Report.Rmd",append=TRUE)
+	line = paste0("knitr::include_graphics(\"",peakExamplePlot,"\")")
+	write(line,file="Report.Rmd",append=TRUE)
+	line = "```"
+	write(line,file="Report.Rmd",append=TRUE)
+	line="```{r, echo=FALSE, out.width='50%', fig.align=\"center\"}"
+	write(line,file="Report.Rmd",append=TRUE)
+
+	line = paste0("knitr::include_graphics(\"",heatmap,"\")")
+	write(line,file="Report.Rmd",append=TRUE)
+	line = "```"
+	write(line,file="Report.Rmd",append=TRUE)
+	line = "\n"
+	write(line,file="Report.Rmd",append=TRUE)
+}
+
+#create master Report Template
+#includes everything except for genome coverage plots
+rmarkdown::render('Report.Rmd', output_file = 'Report.html')
+
+#Delete intermediate coverage Reports and plots
+system(sprintf("rm Report.Rmd"))

--- a/cnr.createReportHTMLTemplate.Rmd
+++ b/cnr.createReportHTMLTemplate.Rmd
@@ -1,0 +1,236 @@
+---
+output:
+    html_document:
+    df_print: kable
+---
+
+```{r setup, include=FALSE}
+knitr::opts_chunk$set(echo = TRUE)
+```
+
+```{r, echo=FALSE, out.width="50%", message=FALSE, warning=FALSE, fig.align='center'}
+knitr::include_graphics(logo)
+```
+
+# {.tabset}
+
+## Alignment Statistics {.tabset}
+\
+```{r insert-tables, echo=FALSE, message=FALSE, warning=FALSE}
+	alnStat <-read.table(paste0(qcDir, "/alignStat.txt"), sep="	", header=T, check.names = FALSE)
+	colnames(alnStat) <- c("Sample","Total Fragments","Uniquely Aligned","Multi-Aligned","% Uniquely Aligned", "% Multi-Aligned", "% Too Many Multi-Aligned", "% Mismatch", "% Too Short", "% Other")
+	kable(format(alnStat, big.mark=",", scientific=FALSE), align="lrrrrrrrrr") %>%
+	kable_styling(full_width = T, bootstrap_options = "bordered") %>%
+	row_spec(0, align = "c", extra_css = 'vertical-align: middle !important;') %>%
+	column_spec(1, bold = T)
+```
+
+## Unique Fragment Counts {.tabset}
+\
+```{r insert-uniq-stats, echo=FALSE, message=FALSE, warning=FALSE}
+    uniqCnt <-read.table(paste0(qcDir, "/uniqFragCnt.txt"), sep="\t", header=T)
+	colnames(uniqCnt) <- c("Sample","Total Fragments","Unique Fragments","% Unique Fragments")
+	kable(format(uniqCnt, big.mark=",", scientific=FALSE), align="lrrr") %>%
+	kable_styling(full_width = T, bootstrap_options = "bordered") %>%
+	row_spec(0, align = "c") %>%
+	column_spec(1, bold = T)
+```
+\
+```{r TTCvsUniqFrac, echo=FALSE, message=FALSE, warning=FALSE}
+	inTable <- read.table(paste0(qcDir, "/uniqFragCnt.txt"), header= T)
+	data <- as.data.frame.matrix(inTable)
+	data[,"logTTC"] <- log10(data[2]+1)
+	fig <- plot_ly(data = inTable, x = ~data$logTTC, y = ~data$UniqFrac, mode = "markers", color = ~data$Name, marker=list(size=11), width = 900, height = 700) %>%
+	layout(title= 'Total Fragment Count vs % of Unique Fragments', xaxis = list(title = 'log10(Total Fragments)', range=list(0, max(data$logTTC, na.rm = TRUE)+1)), yaxis = list(title = 'Unique Fragments (%)', range=list(0,100)), plot_bgcolor="gray89",
+		xaxis = list(gridcolor = "white"),
+		yaxis = list(gridcolor = "white"))
+	fig
+```
+\
+```{r TTCvsCount, echo=FALSE, message=FALSE, warning=FALSE}
+	inTable <- read.table(paste0(qcDir, "/uniqFragCnt.txt"), header= T)
+	data <- as.data.frame.matrix(inTable)
+	fig1 <- plot_ly(data = inTable, x = ~data$TTC, y = ~data$Name, type = "bar", width = 900, height = 700) %>%
+	layout(title="Total Number of Fragments", xaxis = list(title = 'Count'), yaxis = list(title = 'Sample'))
+	fig1
+```
+\
+```{r uniqFragvsCount, echo=FALSE, message=FALSE, warning=FALSE}
+	inTable <- read.table(paste0(qcDir, "/uniqFragCnt.txt"), header= T)
+	data <- as.data.frame.matrix(inTable)
+	fig2 <- plot_ly(data = inTable, x = ~data$UniqCnt, y = ~data$Name, type = "bar", width = 900, height = 700) %>%
+	layout(title="Number of Unique Fragments", xaxis = list(title = 'Count'), yaxis = list(title = 'Sample'))
+	fig2
+```
+\
+```{r percentUniqFragvsCount, echo=FALSE, message=FALSE, warning=FALSE}
+	inTable <- read.table(paste0(qcDir, "/uniqFragCnt.txt"), header= T)
+	data <- as.data.frame.matrix(inTable)
+	fig3 <- plot_ly(data = inTable, x = ~data$UniqFrac, y = ~data$Name, type = "bar", width = 900, height = 700) %>%
+	layout(title="% of Unique Fragments", xaxis = list(title = 'Fraction (%)'), yaxis = list(title = 'Sample'))
+	fig3
+```
+
+## Base Frequencies {.tabset}
+\
+```{r PCA_base_freq, echo=FALSE, out.width="100%", message=FALSE, warning=FALSE}
+	#initialize df and sample name list for header labeling
+	df <- data.frame(matrix(NA, nrow = 160, ncol = length(sampleQC)))
+	sampleNameList <- list()
+	i = 1
+
+	#loop through all samples' QC directories to get baseFreq.txt file
+	for (sample in sampleQC) {
+
+		sampleName <- tail(unlist(strsplit(sample, "/")), n=2)[1]
+
+		#read table
+		inTable <- read.table(paste0(sample, "/base_freq.txt"), header = TRUE, sep = "\t")
+
+		#get rid of first column with offset values
+		inTable$Offset = NULL
+
+		#collapse matrix into 1d array
+		collapsed <- data.frame( samp = c(t(inTable)), stringsAsFactors=FALSE)
+
+		#add 1d array to df
+		df[, i] <- collapsed
+
+		#append sample name to sample name list
+		sampleNameList = append(sampleNameList, sampleName)
+		i = i + 1
+	}
+
+	#transpose
+	tdf = t(df)
+
+	#transposing a df somehow does not allow me to change the data type to num. Saving and reloading automatically reads values as num. Strange and tedious
+	write.table(tdf, file='tdf.tsv', quote=FALSE, sep='\t', col.names = FALSE, row.names = FALSE)
+	inTotalTable <- read.table("tdf.tsv", header = FALSE, sep = "\t")
+
+	system(sprintf(paste0("rm tdf.tsv")))
+
+	#change row names to headers
+	row.names(inTotalTable) <- sampleNameList
+
+	#PCA on data with more datapoints than number of samples causes errors
+	#Workaround by clustering (k = number of samples)
+	pcaSamples <- prcomp(inTotalTable)
+	samplesHC <- hclust(dist(pcaSamples$x),method = "ward.D2")
+	samplesClusters <- cutree(samplesHC,k=nrow(inTotalTable))
+	samplesDF <- data.frame(pcaSamples$x,"cluster"=factor(samplesClusters))
+	samplesDF <- transform(samplesDF, cluster_name = rownames(samplesDF))
+
+	#Draw PCA plot
+	p <- plot_ly(samplesDF, x=pcaSamples$x[,1], y=pcaSamples$x[,2], text=rownames(samplesDF),
+				mode="markers", color = rownames(samplesDF), marker=list(size=11))
+	p <- layout(p,title="Base Frequencies PCA Analysis",
+				xaxis=list(title="PC1 (% of Variance Explained)"),
+				yaxis=list(title="PC2 (% of Variance Explained)"))
+	p
+
+```
+\
+\
+```{r insert-base-freq, echo=FALSE, out.width="50%", message=FALSE, warning=FALSE}
+	baseFreqPaths <- list.files(sampleQC, pattern = "*_freq.png", full.names = TRUE)
+	knitr::include_graphics(baseFreqPaths)
+```
+
+## Fragment Distribution {.tabset}
+\
+```{r frag-dist, echo=FALSE, message=FALSE, warning=FALSE}
+	tableList <- list.files(sampleQC, pattern = "fragLen.dist.txt", full.names = TRUE)
+
+	#fix x-axis since it's the same throughout all distribution.txt files
+	fragLen <- read.table(tableList[1], header=T)[1]
+	data <- data.frame(fragLen)
+
+	#merge a data into one dataframe
+	for (currTable in tableList) {
+		#get sampleName
+		sampleName <- toString(tail(as.list(strsplit(currTable, "/")[[1]]), 3)[1])
+
+		#read in current sample data as a table
+		tmpData <- read.table(currTable, header=T)
+
+		#insert sample distribution as a new column to the existing dataframe
+		data[,sampleName] <- tmpData[2]
+	}
+
+	#overlay plots
+	fig <- plot_ly(data, x=~fragLen, width = 850, height = 400)
+	for (col in 2:ncol(data)) {
+		#get col name
+		colName <- colnames(data[col])
+
+		#insert data into figure
+		fig <- fig %>% add_trace(y = data[ , col], name = colName, type= 'scatter', mode = 'lines') %>%
+		layout(title= 'Fragment Distribution (Raw)', xaxis = list(title = 'Fragment Length'), yaxis = list(title = 'Fragment Count'))
+	}
+
+	fig
+```
+\
+
+```{r frag-density, echo=FALSE, message=FALSE, warning=FALSE}
+	tableList <- list.files(sampleQC, pattern = "fragLen.dist.txt", full.names = TRUE)
+
+	#fix x-axis since it's the same throughout all distribution.txt files
+	fragLen <- read.table(tableList[1], header=T)[1]
+	data <- data.frame(fragLen)
+
+	#merge a data into one dataframe
+	for (currTable in tableList) {
+		#get sampleName
+		sampleName <- toString(tail(as.list(strsplit(currTable, "/")[[1]]), 3)[1])
+
+		#read in current sample data as a table
+		tmpData <- read.table(currTable, header=T)
+
+		#insert sample distribution as a new column to the existing dataframe
+		data[,sampleName] <- tmpData[2]
+	}
+
+	#overlay plots
+	fig <- plot_ly(data, x=~fragLen, width = 850, height = 400)
+	dataNormTemp <- sweep(data, 2,colSums(data), "/")
+	dataNorm <- sweep(dataNormTemp, 2, 1000, "*")
+	for (col in 2:ncol(dataNorm)) {
+		#get col name
+		colName <- colnames(dataNorm[col])
+
+		#insert data into figure
+		fig <- fig %>% add_trace(y = dataNorm[ , col], name = colName, type= 'scatter', mode = 'lines') %>%
+		layout(title= 'Fragment Distribution (Normalized)', xaxis = list(title = 'Fragment Length'), yaxis = list(title = 'Density (RPK)'))
+	}
+
+	fig
+```
+
+## Peak Counts {.tabset}
+\
+```{r peak-counts-TF, echo=FALSE, message=FALSE, warning=FALSE}
+	if (nrow(factorTable) != 0) {
+		colnames(factorTable) <- c("Sample","Number of Peaks")
+		kable(format(factorTable, big.mark=",", scientific=FALSE), align="lr", caption = "Peak counts for Transcription Factor samples") %>%
+		kable_styling(full_width = T, bootstrap_options = "bordered") %>%
+		row_spec(0, align = "c") %>%
+		column_spec(1, bold = T)
+	}
+
+```
+
+\
+```{r peak-counts-hist, echo=FALSE, message=FALSE, warning=FALSE}
+	if (nrow(histoneTable) != 0) {
+		colnames(histoneTable) <- c("Sample","Number of Peaks","Total Peak Width (bp)")
+		kable(format(histoneTable, big.mark=",", scientific=FALSE), align="lrr", caption = "Peak counts for Histone samples") %>%
+		kable_styling(full_width = T, bootstrap_options = "bordered") %>%
+		row_spec(0, align = "c") %>%
+		column_spec(1, bold = T)
+	}
+
+```
+
+## Peak Examples {.tabset}

--- a/cnr.visualizePeakExamples.r
+++ b/cnr.visualizePeakExamples.r
@@ -1,0 +1,479 @@
+#!/usr/bin/env Rscript
+
+# source("/Volumes/limlab/ChristopherAhn/create_pdf_py/genomeR.r")
+# source("/Volumes/limlab/ChristopherAhn/create_pdf_py/basicR.r")
+source(sprintf("%s/genomeR.r", Sys.getenv("COMMON_LIB_BASE")))
+source(sprintf("%s/basicR.r", Sys.getenv("COMMON_LIB_BASE")))
+
+suppressPackageStartupMessages(library('optparse', quiet=TRUE))
+suppressPackageStartupMessages(library('ggplot2', quiet=TRUE))
+suppressPackageStartupMessages(library('reshape2', quiet=TRUE))
+suppressPackageStartupMessages(library('cowplot', quiet=TRUE))
+
+option_list <- list(
+    make_option(c("-o","--outDir"), help="Path to output directory"),
+    make_option(c("-m","--mode"), help="Peak mode; Enter 'histone' or 'factor'"),
+    make_option(c("-c","--ctrlName"), help="Name of control sample; 'NULL' if there is no control sample"),
+    make_option(c("-n","--numPeaks"), help="Number of highest scoring peaks to visualize; should be an integer")
+)
+
+parser <- OptionParser(usage = "%prog",
+	description="Description:
+	Takes a peak file to visualize the top 6 high scoring peak regions and save as images.
+Input:
+	sample/directory
+Output:
+    - <snapshot>.png",
+	 option_list=option_list)
+arguments <- parse_args(parser, positional_arguments = TRUE)
+
+# Option handling
+opt=arguments$options
+outDir=opt$outDir
+mode=opt$mode
+ctrlSampleName=opt$ctrlName
+numHighestPeaks=opt$numPeaks
+peakFilePath <- arguments$args
+
+draw_peak_example=function(bed, nucBW, nfrBW, ctrlNucBW, ctrlNfrBW, windowSize = 10000, binsize = 20, des=NULL){
+#draw coverage plot for all peaks in a bed file. Requires a bed file and at least two bigwig files.
+#ctrl bigwig files are "NULL" by default, unless specified
+#binsize for extractBigWigData is 20 by default
+#window size for extractBigWigData is 10000 by default
+#required packages: ggplot2, reshape2, cowplot
+    
+    #if control sample exists
+    if (!is.null(ctrlNucBW)) {
+
+		#extract by 10bp
+		nucPeakTable <- extractBigWigData(bed = bed, bw = nucBW, width = windowSize, binSize = binsize)
+		nfrPeakTable <- extractBigWigData(bed = bed, bw = nfrBW, width = windowSize, binSize = binsize)
+		nucCtrlTable <- extractBigWigData(bed = bed, bw = ctrlNucBW, width = windowSize, binSize = binsize)
+		nfrCtrlTable <- extractBigWigData(bed = bed, bw = ctrlNfrBW, width = windowSize, binSize = binsize)
+
+		#convert to DF and transpose
+		nucdf <- as.data.frame(t(nucPeakTable))
+		nfrdf <- as.data.frame(t(nfrPeakTable))
+		ctrlNucdf <- as.data.frame(t(nucCtrlTable))
+		ctrlNfrdf <- as.data.frame(t(nfrCtrlTable))
+		tempNUC <- as.data.frame(t(nucPeakTable))
+		tempNFR <- as.data.frame(t(nfrPeakTable))
+
+		#Add x axis numbering
+		tempNUC <- cbind(rows = 1:nrow(tempNUC), tempNUC)
+
+		#remove unnecessary columns
+		#this is due to errors when trying to create a new dataframe. Tedious work...
+        tempNUC = tempNUC[,1:3]
+
+		#rename column headers
+		colnames(tempNUC) <- c("rows", "NUC", "NUC_Ctrl")
+
+		#Add x axis numbering
+		tempNFR <- cbind(rows = 1:nrow(tempNFR), tempNFR)
+		#this is due to errors when trying to create a new dataframe. Tedious work...
+		tempNFR = tempNFR[,1:3]
+
+		#rename column headers
+		colnames(tempNFR) <- c("rows", "NFR", "NFR_Ctrl")
+
+		#read peak file
+		peakFile <- read.table(bed, header = FALSE, sep = "\t")
+
+        #create empty list of images
+        listOfPlots <- list()
+
+		#append images vertically
+		#create plots
+		for (col in 1:ncol(nucdf)) {
+
+			#get peak start
+			peakStart <- peakFile[col,2]
+			chr <- peakFile[col,1]
+
+			#get x axis range
+			xRange <- peakStart:(peakStart + (windowSize/binsize) - 1)
+			xRange <- xRange * binsize
+
+			#modify column values
+			tempNUC[1] <- xRange
+			tempNFR[1] <- xRange
+
+			tempNFR[2] <- nfrdf[col]
+			tempNFR[3] <- ctrlNfrdf[col]
+			tempNUC[2] <- nucdf[col]
+			tempNUC[3] <- ctrlNucdf[col]
+
+			#replace zeros to NA
+			tempNFR[tempNFR == NA] <- 0
+			tempNUC[tempNUC == NA] <- 0
+
+			tempNUC.melt <- melt(tempNUC, id.vars = 'rows', variable.name = 'series')
+			tempNFR.melt <- melt(tempNFR, id.vars = 'rows', variable.name = 'series')
+
+			#define an array of type for color coding
+			colorTypeNUC=rep(c("blue", "grey43"), each=(nrow(tempNUC.melt)/2))
+			colorTypeNFR=rep(c("red", "grey43"), each=(nrow(tempNFR.melt)/2))
+
+			tempNUC.melt$color <- colorTypeNUC
+			tempNFR.melt$color <- colorTypeNFR
+
+            #check if max RPM is zero in both the sample and the control. If so, ylim has to be manually set
+            nucMax <- max(tempNUC.melt$value, na.rm = TRUE)
+            nfrMax <- max(tempNFR.melt$value, na.rm = TRUE)
+
+            #if max RPM in nfr bw is zero, set ylim manually
+            if (nfrMax == 0) {
+                NFR <- ggplot(tempNFR.melt, aes(rows,value)) +
+                        geom_area(colour=tempNFR.melt$color, fill=tempNFR.melt$color) + 
+                        facet_grid(series ~ .) + 
+                        #labs(title=paste0("Highest Scoring Peak #", col), x = chr, y = "Score") +
+                        #labs(x = chr, y = "Score") +
+                        labs(title=paste0("Highest Scoring Peak #", col), y = "Score") +
+                        theme(plot.title = element_text(hjust = 0.5, face="bold"),
+                            panel.background = element_blank(),
+                            panel.grid.major = element_blank(),
+                            panel.grid.minor = element_blank(),
+                            axis.line = element_line(colour = "black"),
+                            panel.border = element_rect(colour = "black", fill=NA),
+                            axis.title.x = element_blank(),
+                            axis.text.x = element_blank(),
+                            axis.ticks.x = element_blank(),
+                            axis.title.y = element_text(colour="white")
+                            #axis.title.y = element_blank()
+                            #plot.margin=grid::unit(c(0,0,0,0), "mm"),
+                            #aspect.ratio=1/4
+                            ) +
+                        theme(strip.background = element_rect(fill="red")) +
+                        theme(strip.text = element_text(colour = 'white', face="bold", size = 14)) +
+                        ylim(0, 5)
+                        #scale_y_continuous(labels = scales::number_format(accuracy = 0.1))
+            
+            #if max RPM in nfr bw is not zero, let ggplot automatically set ylim
+            } else {
+                NFR <- ggplot(tempNFR.melt, aes(rows,value)) +
+                        geom_area(colour=tempNFR.melt$color, fill=tempNFR.melt$color) + 
+                        facet_grid(series ~ .) + 
+                        #labs(title=paste0("Highest Scoring Peak #", col), x = chr, y = "Score") +
+                        #labs(x = chr, y = "Score") +
+                        labs(title=paste0("Highest Scoring Peak #", col), y = "Score") +
+                        theme(plot.title = element_text(hjust = 0.5, face="bold"),
+                            panel.background = element_blank(),
+                            panel.grid.major = element_blank(),
+                            panel.grid.minor = element_blank(),
+                            axis.line = element_line(colour = "black"),
+                            panel.border = element_rect(colour = "black", fill=NA),
+                            axis.title.x = element_blank(),
+                            axis.text.x = element_blank(),
+                            axis.ticks.x = element_blank(),
+                            axis.title.y = element_text(colour="white")
+                            #axis.title.y = element_blank()
+                            #plot.margin=grid::unit(c(0,0,0,0), "mm"),
+                            #aspect.ratio=1/4
+                            ) +
+                        theme(strip.background = element_rect(fill="red")) +
+                        theme(strip.text = element_text(colour = 'white', face="bold", size = 14))
+                        #scale_y_continuous(labels = scales::number_format(accuracy = 0.1))
+            }
+
+            #if max RPM in nuc bw is zero, set ylim manually
+            if (nucMax == 0) {
+                NUC <- ggplot(tempNUC.melt, aes(rows,value)) +
+                    geom_area(colour=tempNUC.melt$color, fill=tempNUC.melt$color) + 
+                    facet_grid(series ~ .) + 
+                    #labs(title=paste0("Highest Scoring Peak #", col), x = chr, y = "Score") +
+                    labs(x = chr, y = "Score") +
+                    theme(#plot.title = element_text(hjust = 0.5, face="bold"),
+                        panel.background = element_blank(),
+                        panel.grid.major = element_blank(),
+                        panel.grid.minor = element_blank(),
+                        axis.line = element_line(colour = "black"),
+                        panel.border = element_rect(colour = "black", fill=NA),
+                        axis.title.x = element_text(face="bold"),
+                        #axis.title.y = element_blank()
+                        axis.title.y = element_text(colour="white")
+                        #plot.margin=grid::unit(c(0,0,0,0), "mm"),
+                        #aspect.ratio=1/4
+                        ) +
+                    theme(strip.background = element_rect(fill="blue")) +
+                    theme(strip.text = element_text(colour = 'white', face="bold", size = 14)) +
+                    ylim(0, 5)
+                    #scale_y_continuous(labels = scales::number_format(accuracy = 0.1))
+            
+            #if max RPM in nuc bw is not zero:
+            } else {
+                NUC <- ggplot(tempNUC.melt, aes(rows,value)) +
+                    geom_area(colour=tempNUC.melt$color, fill=tempNUC.melt$color) + 
+                    facet_grid(series ~ .) + 
+                    #labs(title=paste0("Highest Scoring Peak #", col), x = chr, y = "Score") +
+                    labs(x = chr, y = "Score") +
+                    theme(#plot.title = element_text(hjust = 0.5, face="bold"),
+                        panel.background = element_blank(),
+                        panel.grid.major = element_blank(),
+                        panel.grid.minor = element_blank(),
+                        axis.line = element_line(colour = "black"),
+                        panel.border = element_rect(colour = "black", fill=NA),
+                        axis.title.x = element_text(face="bold"),
+                        #axis.title.y = element_blank()
+                        axis.title.y = element_text(colour="white")
+                        #plot.margin=grid::unit(c(0,0,0,0), "mm"),
+                        #aspect.ratio=1/4
+                        ) +
+                    theme(strip.background = element_rect(fill="blue")) +
+                    theme(strip.text = element_text(colour = 'white', face="bold", size = 14))
+                    #scale_y_continuous(labels = scales::number_format(accuracy = 0.1))
+            }
+
+            #merge both nfr and nuc visualizations vertically
+			merged <- plot_grid(NFR, NUC, ncol = 1, align = "v")
+
+            #create y-axis label
+            newMerged <- ggdraw(merged) +
+            draw_label("RPM", x=0.01, y=0.5, vjust=0.5, hjust=0.5, angle = 90, fontface="bold", size = 12)
+
+            #append current sample's peak example visualization to a list
+            listOfPlots <- append(listOfPlots, list(newMerged))
+
+        } #end of loop to create plots
+
+        #merge all peak examples
+        allMerged <- plot_grid(plotlist=listOfPlots, ncol = 1, align = "v")
+
+        #save peak examples as png and pdf
+        ggsave(paste0(des, "/", "peak.examples.png"), allMerged, width = 10, height = (strtoi(numHighestPeaks) * 6), dpi = 500, units = "in", device = "png")
+        ggsave(paste0(des, "/", "peak.examples.pdf"), allMerged, width = 10, height = (strtoi(numHighestPeaks) * 6), dpi = 500, units = "in", device = "pdf")
+
+    
+    #if a control sample does not exist
+    #do not visualize control samples
+	} else {
+
+		#extract by 10bp
+		nucPeakTable <- extractBigWigData(bed = bed, bw = nucBW, width = windowSize, binSize = binsize)
+		nfrPeakTable <- extractBigWigData(bed = bed, bw = nfrBW, width = windowSize, binSize = binsize)
+
+		#convert to DF and transpose
+		nucdf <- as.data.frame(t(nucPeakTable))
+		nfrdf <- as.data.frame(t(nfrPeakTable))
+		tempNUC <- as.data.frame(t(nucPeakTable))
+		tempNFR <- as.data.frame(t(nfrPeakTable))
+
+		#Add x axis numbering
+		tempNUC <- cbind(rows = 1:nrow(tempNUC), tempNUC)
+		#remove unnecessary columns (last two)
+		#this is due to errors when trying to create a new dataframe. Tedious work...
+        tempNUC = tempNUC[,1:2]
+
+		#rename column headers
+		colnames(tempNUC) <- c("rows", "NUC")
+
+		#Add x axis numbering
+		tempNFR <- cbind(rows = 1:nrow(tempNFR), tempNFR)
+		#remove unnecessary columns (last two)
+		#this is due to errors when trying to create a new dataframe. Tedious work...
+        tempNFR = tempNFR[,1:2]
+
+		#rename column headers
+		colnames(tempNFR) <- c("rows", "NFR")
+
+
+		#read peak file
+		peakFile <- read.table(bed, header = FALSE, sep = "\t")
+
+        #create empty list of images
+        listOfPlots <- list()
+
+		#append images vertically
+		#create plots
+		for (col in 1:ncol(nucdf)) {
+
+			#get peak start
+			peakStart <- peakFile[col,2]
+			chr <- peakFile[col,1]
+
+			#get x axis range
+			xRange <- peakStart:(peakStart + (windowSize/binsize) - 1)
+			xRange <- xRange * binsize
+
+			#modify column values
+			tempNUC[1] <- xRange
+			tempNFR[1] <- xRange
+
+			tempNFR[2] <- nfrdf[col]
+			tempNUC[2] <- nucdf[col]
+
+			#replace zeros to NA
+			tempNFR[tempNFR == NA] <- 0
+			tempNUC[tempNUC == NA] <- 0
+
+			tempNUC.melt <- melt(tempNUC, id.vars = 'rows', variable.name = 'series')
+			tempNFR.melt <- melt(tempNFR, id.vars = 'rows', variable.name = 'series')
+
+			#define an array of type for color coding
+			colorTypeNUC=rep(c("blue"), each=(nrow(tempNUC.melt)))
+			colorTypeNFR=rep(c("red"), each=(nrow(tempNFR.melt)))
+
+			tempNUC.melt$color <- colorTypeNUC
+			tempNFR.melt$color <- colorTypeNFR
+            nucMax <- max(tempNUC.melt$value, na.rm = TRUE)
+            nfrMax <- max(tempNFR.melt$value, na.rm = TRUE)
+
+            #if max RPM in nfr bw is zero, set ylim manually
+            if (nfrMax == 0) {
+                NFR <- ggplot(tempNFR.melt, aes(rows,value)) +
+                        geom_area(colour=tempNFR.melt$color, fill=tempNFR.melt$color) + 
+                        facet_grid(series ~ .) + 
+                        #labs(title=paste0("Highest Scoring Peak #", col), x = chr, y = "Score") +
+                        #labs(x = chr, y = "Score") +
+                        labs(title=paste0("Highest Scoring Peak #", col), y = "Score") +
+                        theme(plot.title = element_text(hjust = 0.5, face="bold"),
+                            panel.background = element_blank(),
+                            panel.grid.major = element_blank(),
+                            panel.grid.minor = element_blank(),
+                            axis.line = element_line(colour = "black"),
+                            panel.border = element_rect(colour = "black", fill=NA),
+                            axis.title.x = element_blank(),
+                            axis.text.x = element_blank(),
+                            axis.ticks.x = element_blank(),
+                            axis.title.y = element_text(colour="white")
+                            #axis.title.y = element_blank()
+                            #plot.margin=grid::unit(c(0,0,0,0), "mm"),
+                            #aspect.ratio=1/4
+                            ) +
+                        theme(strip.background = element_rect(fill="red")) +
+                        theme(strip.text = element_text(colour = 'white', face="bold", size = 14)) +
+                        ylim(0, 5)
+                        #scale_y_continuous(labels = scales::number_format(accuracy = 0.1))
+            
+            #if max RPM in nfr bw is zero, set ylim automatically
+            } else {
+                NFR <- ggplot(tempNFR.melt, aes(rows,value)) +
+                        geom_area(colour=tempNFR.melt$color, fill=tempNFR.melt$color) + 
+                        facet_grid(series ~ .) + 
+                        #labs(title=paste0("Highest Scoring Peak #", col), x = chr, y = "Score") +
+                        #labs(x = chr, y = "Score") +
+                        labs(title=paste0("Highest Scoring Peak #", col), y = "Score") +
+                        theme(plot.title = element_text(hjust = 0.5, face="bold"),
+                            panel.background = element_blank(),
+                            panel.grid.major = element_blank(),
+                            panel.grid.minor = element_blank(),
+                            axis.line = element_line(colour = "black"),
+                            panel.border = element_rect(colour = "black", fill=NA),
+                            axis.title.x = element_blank(),
+                            axis.text.x = element_blank(),
+                            axis.ticks.x = element_blank(),
+                            axis.title.y = element_text(colour="white")
+                            #axis.title.y = element_blank()
+                            #plot.margin=grid::unit(c(0,0,0,0), "mm"),
+                            #aspect.ratio=1/4
+                            ) +
+                        theme(strip.background = element_rect(fill="red")) +
+                        theme(strip.text = element_text(colour = 'white', face="bold", size = 14))
+                        #scale_y_continuous(labels = scales::number_format(accuracy = 0.1))
+            }
+
+            #if max RPM in nuc bw is zero, set ylim manually
+            if (nucMax == 0) {
+                NUC <- ggplot(tempNUC.melt, aes(rows,value)) +
+                    geom_area(colour=tempNUC.melt$color, fill=tempNUC.melt$color) + 
+                    facet_grid(series ~ .) + 
+                    #labs(title=paste0("Highest Scoring Peak #", col), x = chr, y = "Score") +
+                    labs(x = chr, y = "Score") +
+                    theme(#plot.title = element_text(hjust = 0.5, face="bold"),
+                        panel.background = element_blank(),
+                        panel.grid.major = element_blank(),
+                        panel.grid.minor = element_blank(),
+                        axis.line = element_line(colour = "black"),
+                        panel.border = element_rect(colour = "black", fill=NA),
+                        axis.title.x = element_text(face="bold"),
+                        #axis.title.y = element_blank()
+                        axis.title.y = element_text(colour="white")
+                        #plot.margin=grid::unit(c(0,0,0,0), "mm"),
+                        #aspect.ratio=1/4
+                        ) +
+                    theme(strip.background = element_rect(fill="blue")) +
+                    theme(strip.text = element_text(colour = 'white', face="bold", size = 14)) +
+                    ylim(0, 5)
+                    #scale_y_continuous(labels = scales::number_format(accuracy = 0.1))
+            
+            #if max RPM in nuc bw is zero, set ylim automatically
+            } else {
+                NUC <- ggplot(tempNUC.melt, aes(rows,value)) +
+                    geom_area(colour=tempNUC.melt$color, fill=tempNUC.melt$color) + 
+                    facet_grid(series ~ .) + 
+                    #labs(title=paste0("Highest Scoring Peak #", col), x = chr, y = "Score") +
+                    labs(x = chr, y = "Score") +
+                    theme(#plot.title = element_text(hjust = 0.5, face="bold"),
+                        panel.background = element_blank(),
+                        panel.grid.major = element_blank(),
+                        panel.grid.minor = element_blank(),
+                        axis.line = element_line(colour = "black"),
+                        panel.border = element_rect(colour = "black", fill=NA),
+                        axis.title.x = element_text(face="bold"),
+                        #axis.title.y = element_blank()
+                        axis.title.y = element_text(colour="white")
+                        #plot.margin=grid::unit(c(0,0,0,0), "mm"),
+                        #aspect.ratio=1/4
+                        ) +
+                    theme(strip.background = element_rect(fill="blue")) +
+                    theme(strip.text = element_text(colour = 'white', face="bold", size = 14))
+                    #scale_y_continuous(labels = scales::number_format(accuracy = 0.1))
+            }
+
+            #merge nfr and nuc plots for the current sample
+			merged <- plot_grid(NFR, NUC, ncol = 1, align = "v")
+
+            #create y-axis label
+            newMerged <- ggdraw(merged) +
+            draw_label("RPM", x=0.01, y=0.5, vjust=0.5, hjust=0.5, angle = 90, fontface="bold", size = 12)
+
+            #append current sample's peak example visualization to a list
+            listOfPlots <- append(listOfPlots, list(newMerged))
+
+		}
+
+        #merge all peak examples
+        allMerged <- plot_grid(plotlist=listOfPlots, ncol = 1, align = "v")
+
+        #save peak examples as png and pdf
+        ggsave(paste0(des, "/", "peak.examples.png"), allMerged, width = 10, height = (strtoi(numHighestPeaks) * 3), dpi = 500, units = "in", device = "png")
+        ggsave(paste0(des, "/", "peak.examples.pdf"), allMerged, width = 10, height = (strtoi(numHighestPeaks) * 3), dpi = 500, units = "in", device = "pdf")
+
+	}
+
+}
+
+
+#__main__
+sampTemp <- head(unlist(strsplit(peakFilePath, "/")), -2)
+sampDir <- paste(sampTemp, collapse = '/')
+
+#Parse string to get sample Name
+sampleName <- tail(unlist(strsplit(sampDir, "/")), n=1)
+
+#set both nuc and nfr bw files
+nucBW <- paste(sampDir, "/igv.nuc.con.bw", sep="")
+nfrBW <- paste(sampDir, "/igv.nfr.con.bw", sep="")
+
+#parse control sample
+if (ctrlSampleName == "NULL") {
+    ctrlNucBW <- NULL
+    ctrlNfrBW <- NULL
+} else {
+    ctrlNucBW <- (paste0(getwd(), "/3.Sample/", ctrlSampleName, "/igv.nuc.con.bw"))
+    ctrlNfrBW <- (paste0(getwd(), "/3.Sample/", ctrlSampleName, "/igv.nfr.con.bw"))
+}
+
+system(sprintf(paste0("head -n ", numHighestPeaks, " ", peakFilePath, " > ", outDir, "/topPeaks.bed")))
+
+if (mode == 'factor') {
+    windowSize = 1000
+    binsize = 2
+} else {
+    windowSize = 10000
+    binsize = 20
+}
+
+draw_peak_example(paste0(outDir, "/topPeaks.bed"), nucBW = nucBW, nfrBW = nfrBW, ctrlNucBW = ctrlNucBW, ctrlNfrBW = ctrlNfrBW, windowSize = windowSize, binsize = binsize, des=outDir)
+
+system(sprintf(paste0("rm ", outDir, "/topPeaks.bed")))


### PR DESCRIPTION
The main purpose of this pull request is to upload a working version of Cutlery that includes new features and test/learn how github branching performs. There have been modifications to 3 existing files and 3 new scripts have been created to generate peak examples and an HTML report.

Modified scripts:
	•	Snakemake
	•	rules.post.smk
	•	cluster.yml

Newly added scripts:
	•	cnr.reportTemplate.Rmd
	•	cnr.visualizePeakExamples.r
	•	cnr.createReportHTML.r

Peak example visualization and report generation has been successfully tested on the following datasets:
	•	MichaelRosen data
	•	GSX data

Although this is a working version, some modifications still need to be made for optimization purposes (e.g. setting variable output files for the "draw_peak_examples" rule; this rule is currently split into two rules which run separately for histone and TF samples)

The original repository and branch need to be cloned to a local machine in order to be tested before merging to the master repo.

[Github Tutorial.pptx](https://github.com/hwlim/Cutlery/files/7187194/Github.Tutorial.pptx)
