### PR TITLE
Changes to input, output, and help messages

### DIFF
--- a/Script/cnr.createReportHTML.r
+++ b/Script/cnr.createReportHTML.r
@@ -11,7 +11,8 @@ suppressPackageStartupMessages(library('magick', quiet=TRUE))
 option_list <- list(
 	make_option(c("-o","--outputFile"), help="prefix to output file; Can include path as well"),
 	make_option(c("-s","--sampleDir"), help="Path to the Sample Folder, defined by 'sampleDir'"),
-	make_option(c("-q","--qcDir"), help="Path to the Quality Control Folder, defined by 'qcDir'")
+	make_option(c("-q","--qcDir"), help="Path to the Quality Control Folder, defined by 'qcDir'"),
+	make_option(c("-f","--fragMixPrefix"), help="prefix for fragMix.txt file; output of frag_QC rule")
 )
 parser <- OptionParser(usage = "%prog [options]",
 	description="Description:
@@ -101,7 +102,7 @@ for (sample in sampleQC) {
 	homerFolderPath <- paste0(sampleDirectory, "/", homerFolderName)
 	
 	#get fragmentQC file for the sample
-	fragQCfile <- paste0(sample, "/frag.QC.txt")
+	fragQCfile <- paste0(sample, "/", opt$fragMixPrefix ,".txt")
 	fragQC <- read.table(fragQCfile, header = TRUE)
 
 	# skip visualization of control samples, but retrieve fragQC

--- a/Script/cnr.createSampleReportHTML.r
+++ b/Script/cnr.createSampleReportHTML.r
@@ -12,7 +12,8 @@ option_list <- list(
 	make_option(c("-o","--outputFile"), help="prefix to output file; Can include path as well"),
 	make_option(c("-g","--groupName"), help="Group name for the sample"),
 	make_option(c("-s","--sampleDir"), help="Path to the Sample Folder, defined by 'sampleDir'"),
-	make_option(c("-q","--qcDir"), help="Path to the Quality Control Folder, defined by 'qcDir'")
+	make_option(c("-q","--qcDir"), help="Path to the Quality Control Folder, defined by 'qcDir'"),
+	make_option(c("-f","--fragMixPrefix"), help="prefix for fragMix.txt file; output of frag_QC rule")
 )
 parser <- OptionParser(usage = "%prog [options]",
 	description="Description:
@@ -23,7 +24,7 @@ Input:
 	Output file name
 Output:
     - Report.html",
-	 option_list=option_list)
+	option_list=option_list)
 arguments <- parse_args(parser, positional_arguments = TRUE)
 
 # Option handling
@@ -97,7 +98,7 @@ peakMode <- tail(unlist(strsplit(homerFolderName, ".", fixed = TRUE)))[2]
 homerFolderPath <- paste0(sampDir, "/", homerFolderName)
 
 #get fragmentQC files for the sample
-fragQCfile <- paste0(sampleQC, "/frag.QC.txt")
+fragQCfile <- paste0(sampleQC, "/", opt$fragMixPrefix ,".txt")
 fragQC <- read.table(fragQCfile, header = TRUE)
 fragLenDist <- paste0(sampleQC, "/fragLen.dist.png")
 

--- a/Snakemake.bySample/Snakefile
+++ b/Snakemake.bySample/Snakefile
@@ -152,7 +152,7 @@ rule all:
 		expand(sampleDir + "/{sampleName}/HomerPeak.histone/peak.examples.{ext}", sampleName=sampleListHistone, ext=["png","pdf"]),
 
 		## Calculate fragment QC
-		expand(sampleDir + "/{sampleName}/QC/frag.QC.txt", sampleName=sampleList),
+		expand(sampleDir + "/{sampleName}/QC/fragMix.txt", sampleName=sampleList),
 
 		## Create report per sample
 		expand(sampleDir + "/{sampleName}/QC/Report.html", sampleName=sampleListHistone),
@@ -178,4 +178,3 @@ Output files under Development
 ## Include Snakemake rules from separate files
 include: os.environ["CUTLERY"] + "/Snakemake.bySample/rules.pre.smk"
 include: os.environ["CUTLERY"] + "/Snakemake.bySample/rules.post.smk"
-

--- a/Snakemake.bySample/rules.post.smk
+++ b/Snakemake.bySample/rules.post.smk
@@ -805,17 +805,16 @@ rule draw_peak_examples_factor:
 
 rule calc_frag_QC:
 	input:
-		fragBed = sampleDir + "/{sampleName}/fragment.bed.gz",
 		fragDist = sampleDir + "/{sampleName}/QC/fragLen.dist.txt"
 	output:
-		sampleDir + "/{sampleName}/QC/frag.QC.txt"
+		sampleDir + "/{sampleName}/QC/fragMix.txt"
 	message:
 		"Performing fragment QC on sample... [{wildcards.sampleName}]"
 	shell:
 		"""
 		module load Cutlery/1.0
-		cnr.calcFragQC.py -o {sampleDir}/{wildcards.sampleName}/QC \
-		{input.fragBed} {input.fragDist}
+		cnr.calcFragMixture.py -o {sampleDir}/{wildcards.sampleName}/QC/fragMix \
+		{input.fragDist}
 		"""
 
 #take sampleName as input
@@ -847,7 +846,7 @@ rule create_report_per_sample:
 		uniqFragCnt = qcDir + "/uniqFragCnt.txt",
 		baseFreqPNG = sampleDir + "/{sampleName}/QC/base_freq.png",
 		fragDistPNG = sampleDir + "/{sampleName}/QC/fragLen.dist.png",
-		fragQC = sampleDir + "/{sampleName}/QC/frag.QC.txt",
+		fragQC = sampleDir + "/{sampleName}/QC/fragMix.txt",
 		peakExample = lambda wildcards: get_peak_example(wildcards.sampleName),
 		heatmap = lambda wildcards: get_heatmap(wildcards.sampleName)
 	output:
@@ -860,7 +859,7 @@ rule create_report_per_sample:
 		"""
 		module load Cutlery/1.0
 		module load ImageMagick/6.9.12
-		cnr.createSampleReportHTML.r -o Report -g {params.group} -s {sampleDir}/{wildcards.sampleName} -q {qcDir}		
+		cnr.createSampleReportHTML.r -o Report -g {params.group} -s {sampleDir}/{wildcards.sampleName} -q {qcDir} -f fragMix
 		"""
 
 
@@ -870,7 +869,7 @@ rule create_final_report:
 		histPeakExamples = expand(sampleDir + "/{sampleName}/HomerPeak.histone/peak.examples.png", sampleName = samples.Name[samples.PeakMode=="histone"].tolist()),
 		tfPeakExamples = expand(sampleDir + "/{sampleName}/HomerPeak.factor/peak.examples.png", sampleName = samples.Name[samples.PeakMode=="factor"].tolist()),
 		fragDist = expand(sampleDir + "/{sampleName}/QC/fragLen.dist.txt", sampleName=samples.Name.tolist()),
-		fragQC = expand(sampleDir + "/{sampleName}/QC/frag.QC.txt", sampleName=samples.Name.tolist()),
+		fragQC = expand(sampleDir + "/{sampleName}/QC/fragMix.txt", sampleName=samples.Name.tolist()),
 		histoneHeatmap = expand(sampleDir + "/{sampleName}/HomerPeak.histone/heatmap.exBL.png", sampleName = samples.Name[samples.PeakMode=="histone"].tolist()),
 		factorHeatmap = expand(sampleDir + "/{sampleName}/HomerPeak.factor/heatmap.exBL.1rpm.png", sampleName = samples.Name[samples.PeakMode=="factor"].tolist())
 	output:
@@ -881,7 +880,7 @@ rule create_final_report:
 		"""
 		module load Cutlery/1.0
 		module load ImageMagick/6.9.12
-		cnr.createReportHTML.r -o Report -s {sampleDir} -q {qcDir}
+		cnr.createReportHTML.r -o Report -s {sampleDir} -q {qcDir} -f fragMix
 		"""
 
 rule create_report_per_sample_pooled:
@@ -889,7 +888,7 @@ rule create_report_per_sample_pooled:
 		uniqFragCnt = qcDir + "/uniqFragCnt.txt",
 		baseFreqPNG = sampleDir + "/{sampleName}/QC/base_freq.png",
 		fragDistPNG = sampleDir + "/{sampleName}/QC/fragLen.dist.png",
-		fragQC = sampleDir + "/{sampleName}/QC/frag.QC.txt",
+		fragQC = sampleDir + "/{sampleName}/QC/fragMix.txt",
 		peakExample = lambda wildcards: get_peak_example(wildcards.sampleName),
 		heatmap = lambda wildcards: get_heatmap(wildcards.sampleName)
 	output:
@@ -910,7 +909,7 @@ rule create_final_report_pooled:
 		histPeakExamples = expand(sampleDir + "/{sampleName}/HomerPeak.histone/peak.examples.png", sampleName = samples.Name[samples.PeakMode=="histone"].tolist()),
 		tfPeakExamples = expand(sampleDir + "/{sampleName}/HomerPeak.factor/peak.examples.png", sampleName = samples.Name[samples.PeakMode=="factor"].tolist()),
 		fragDist = expand(sampleDir + "/{sampleName}/QC/fragLen.dist.txt", sampleName=samples.Name.tolist()),
-		fragQC = expand(sampleDir + "/{sampleName}/QC/frag.QC.txt", sampleName=samples.Name.tolist()),
+		fragQC = expand(sampleDir + "/{sampleName}/QC/fragMix.txt", sampleName=samples.Name.tolist()),
 		histoneHeatmap = expand(sampleDir + "/{sampleName}/HomerPeak.histone/heatmap.exBL.png", sampleName = samples.Name[samples.PeakMode=="histone"].tolist()),
 		factorHeatmap = expand(sampleDir + "/{sampleName}/HomerPeak.factor/heatmap.exBL.1rpm.png", sampleName = samples.Name[samples.PeakMode=="factor"].tolist())
 	output:


### PR DESCRIPTION
This request contains fixes for issue #24.


- The fragment.bed file is no longer required as input.

- The user can designate the output file prefix, where the default value within the script is "fragMix" and the value set in the snakemake rule is "3.Sample/SampleName/QC/fragMix.{txt, GMM.pdf, GMM.png}. Help messages regarding this option have been updated as well.

- This led to changes in the cnr.createReportHTML.r and cnr.createSampleReportHTML.r, where they had "frag.QC.txt" hard-coded into the script. This has been changed so that the script takes the prefix of the fragMix.txt file as an additional input.