### PR TITLE
added baseFreq for chrM

### DIFF
--- a/Snakemake/Snakefile
+++ b/Snakemake/Snakefile
@@ -42,7 +42,7 @@ opt_cutadapt	= ""	# additional option for cutadapt
 ## Regular expressions for chromosome names
 ## Target chromosomes + spikein chromosome (if needed)
 ## This is also useful in excluding all the scaffold and random chromosomes
-chrRegexAll		= "^chr[0-9XY]+$"
+chrRegexAll		= "^chr[0-9XYM]+$"
 ## Target chromosomes
 chrRegexTarget	= "^chr[0-9XY]+$"
 
@@ -136,6 +136,7 @@ rule all:
 		expand(qcDir + "/uniqFragCnt.{ext}", ext=[ "txt", "pdf" ]),
 		expand(sampleDir + "/{sampleName}/QC/fragLen.dist.{ext}", sampleName=sampleList, ext=["txt","png"]),
 		expand(sampleDir + "/{sampleName}/QC/base_freq.{ext}",  sampleName=sampleList, ext=["png","html"]),
+		expand(sampleDir + "/{sampleName}/QC/base_freq_chrM.{ext}",  sampleName=sampleList, ext=["png","html"]),
 		## Bedgraph and BigWig files
 		expand(sampleDir + "/{sampleName}/igv.raw.bedGraph.gz", sampleName=sampleList),
 		expand(sampleDir + "/{sampleName}/igv.{fragment}.ctr.bw", sampleName=sampleList, fragment=["all","nfr","nuc"]),

--- a/Snakemake/cluster.yml
+++ b/Snakemake/cluster.yml
@@ -26,6 +26,10 @@ check_baseFreq:
     cpu         : 2
     memory      : 6000
 
+check_baseFreq_chrM:
+    cpu         : 2
+    memory      : 6000
+
 dedup_align:
     cpu         : 2
     memory      : 6000

--- a/Snakemake/rules.post.smk
+++ b/Snakemake/rules.post.smk
@@ -120,6 +120,20 @@ rule check_baseFreq:
 #		rm {sampleDir}/{wildcards.sampleName}/tmp.R1.bed.gz
 #		rm {sampleDir}/{wildcards.sampleName}/tmp.R2.bed.gz
 
+rule check_baseFreq_chrM:
+	input:
+		frag = sampleDir + "/{sampleName}/fragment.bed.gz",
+	output:
+		expand(sampleDir + "/{{sampleName}}/QC/base_freq_chrM.{ext}", ext=["png","html"])
+	message:
+		"Checking baseFrequency... [{wildcards.sampleName}]"
+	shell:
+		"""
+		module load Cutlery/1.0
+		checkBaseFreq.plot.sh -o {sampleDir}/{wildcards.sampleName}/QC/base_freq_chrM \
+			-n {wildcards.sampleName} -g {genomeFa} -c "^chrM" -m both -l 20 -f -i -v {input.frag}
+		"""
+
 
 ## BAM to fragment bed files: all / nfr / nuc
 rule split_bam:


### PR DESCRIPTION
- Changed "chrRegexAll" in the Snakefile to create fragment.bed files that include chrM reads.
- listed the output file for baseFreq_chrM in the Snakefile
- added the rule "check_baseFreq_chrM", which uses "^chrM" as regex.