### PR TITLE
fix peak heatmap labels

### DIFF
--- a/Script/cnr.drawPeakHeatmap.r
+++ b/Script/cnr.drawPeakHeatmap.r
@@ -92,7 +92,7 @@ N.bed = length(srcL.bed)
 N.bw = length(srcL.bw)
 stopifnot( N.bed > 0 && N.bw > 0 )
 
-#Define column names and re-order bw files if ctrl sample exists
+#Define column names and add labels for ctrl bw files if ctrl sample exists
 if( N.bw == 4 ){
 	nameL.bw = c("NFR", "NUC", "NFR_Ctrl", "NUC_Ctrl")
 	margin = "0,3.8,2.5,3.8"


### PR DESCRIPTION
The "cnr.drawPeakHeatmap.r" script has been modified to match the input order determined by the "get_bw_pairs" function in the "rules.post.smk" file. Modifications include re-ordering the plot labels and correcting axisLim.

I guess it would be a bit tough to _**not**_ hard-code these due to scaling.

New test output on the example data I used looks like the following:
![heatmap exBL 1rpm](https://github.com/hwlim/Cutlery/assets/68922766/944b9fa0-6e3e-451c-985b-f58768bdf86e)
