### PR TITLE
Fix peak examples

### DIFF
--- a/Script/cnr.drawPeakExamples.r
+++ b/Script/cnr.drawPeakExamples.r
@@ -272,8 +272,6 @@ if (mode == 'factor') {
     binsize = 20
 }
 
-#bwFiles = c("3.Sample/Cp_H3K4me1/igv.nfr.con.bw", "3.Sample/Cp_H3K4me1/igv.nuc.con.bw", "3.Sample/Cp_IgG/igv.nfr.con.bw", "3.Sample/Cp_IgG/igv.nuc.con.bw")
-
 #extractBW
 extractedBW = list()
 for (i in seq_along(bwFiles)) {


### PR DESCRIPTION
I've been seeing the following error when running cnr.drawPeakExamples.r:


Error in `geom_area()`:
! Problem while setting up geom aesthetics.
ℹ Error occurred in the 1st layer.
Caused by error in `check_aesthetics()`:
! Aesthetics must be either length 1 or the same as the data (3000).
✖ Fix the following mappings: `colour` and `fill`.
Backtrace:
     ▆
  1. └─global draw_peak_example(...)
  2.   ├─base::append(...)
  3.   └─global create_plots_and_add_to_plot_list(...)
  4.     └─cowplot::plot_grid(NFR, NUC, ncol = 1, align = "v")
  5.       └─cowplot::align_plots(...)
  6.         └─base::lapply(...)
  7.           └─cowplot (local) FUN(X[[i]], ...)
  8.             ├─cowplot::as_gtable(x)
  9.             └─cowplot:::as_gtable.default(x)
 10.               ├─cowplot::as_grob(plot)
 11.               └─cowplot:::as_grob.ggplot(plot)
 12.                 └─ggplot2::ggplotGrob(plot)
 13.                   ├─ggplot2::ggplot_gtable(ggplot_build(x))
 14.                   │ └─ggplot2:::attach_plot_env(data$plot$plot_env)
 15.                   │   └─base::options(ggplot2_plot_env = env)
 16.                   ├─ggplot2::ggplot_build(x)
 17.                   └─ggplot2:::ggplot_build.ggplot(x)
 18.                     └─ggplot2:::by_layer(...)
 19.                       ├─rlang::try_fetch(...)
 20.                       │ ├─base::tryCatch(...)
 21.                       │ │ └─base (local) tryCatchList(expr, classes, parentenv, handlers)
 22.                       │ │   └─base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
 23.                       │ │     └─base (local) doTryCatch(return(expr), name, parentenv, handler)
 24.                       │ └─base::withCallingHandlers(...)
 25.                       └─ggplot2 (local) f(l = layers[[i]], d = data[[i]])
 26.                         └─l$compute_geom_2(d)
 27.                           └─ggplot2 (local) compute_geom_2(..., self = self)
 28.                             └─self$geom$use_defaults(data, self$aes_params, modifiers)
 29.                               └─ggplot2 (local) use_defaults(..., self = self)
 30.                                 └─ggplot2:::check_aesthetics(new_params, nrow(data))
 31.                                   └─cli::cli_abort(...)
 32.                                     └─rlang::abort(...)


This error has been fixed.