### PR TITLE
minor bug fixes

### DIFF
--- a/Script/cnr.createReportHTML.r
+++ b/Script/cnr.createReportHTML.r
@@ -78,7 +78,7 @@ for (sample in sampleQC) {
 	sampleName <- tail(unlist(strsplit(sample, "/")), n=2)[1]
 
 	## get sample info from sample.tsv file
-	rowNum = which(grepl(sampleName, sampleIn$Name))
+	rowNum = which(sampleIn$Name == sampleName)
 	rowData = sampleIn[rowNum,]
 	peakMode = rowData$PeakMode
 

--- a/Script/cnr.createSampleReportHTML.r
+++ b/Script/cnr.createSampleReportHTML.r
@@ -75,7 +75,7 @@ sampleName = tail(unlist(strsplit(sampDir, "/")), n=1)
 sampleQC = paste0(sampDir, "/QC")
 
 ## get sample info from sample.tsv file
-rowNum = which(grepl(sampleName, sampleIn$Name))
+rowNum = which(sampleIn$Name == sampleName)
 rowData = sampleIn[rowNum,]
 peakMode = rowData$PeakMode
 

--- a/Snakemake/cluster.yml
+++ b/Snakemake/cluster.yml
@@ -46,6 +46,10 @@ dedup_align:
     cpu         : 2
     memory      : 6000
 
+make_bedgraph_frag:
+    cpu         : 2
+    memory      : 10000
+
 make_bigwig_ctr:
     cpu         : 2
     memory      : 10000


### PR DESCRIPTION
- Fixed bug where report generation would have trouble parsing "sample.tsv" when one sample name is a substring of another sample name. For example, having both sample names **"isl1_mut_1"** and **"nr2f1a_isl1_mut_1"** caused an issue during sample name parsing.

- Added larger memory limit to "make_bedgraph_frag" rule to prevent job from exiting prematurely due to memory limit